### PR TITLE
Complete MenuItemReviewController: add GET (index), POST (create), GET (show), PUT (edit) and DELETE endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,5 @@ build/
 ### Local Configuration ###
 .env
 .DS_Store
-
+dokku.env
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,6 +1,6 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
 
@@ -12,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,9 +23,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-
-import java.time.LocalDateTime;
-import edu.ucsb.cs156.example.entities.MenuItemReview;
 
 @Tag(name = "MenuItemReview")
 @RequestMapping("/api/menuitemreview")
@@ -55,9 +51,6 @@ public class MenuItemReviewController extends ApiController {
             )
             throws JsonProcessingException {
 
-        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-        // See: https://www.baeldung.com/spring-date-parameters
-
         log.info("station={}", station);
 
         MenuItemReview menuItemReview = new MenuItemReview();
@@ -70,45 +63,45 @@ public class MenuItemReviewController extends ApiController {
         return savedMenuItemReview;
     }
 
-    // @Operation(summary= "Get a single date")
-    // @PreAuthorize("hasRole('ROLE_USER')")
-    // @GetMapping("")
-    // public UCSBDate getById(
-    //         @Parameter(name="id") @RequestParam Long id) {
-    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+    @Operation(summary= "Get a single review")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public MenuItemReview getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
 
-    //     return ucsbDate;
-    // }
+        return menuItemReview;
+    }
 
-    // @Operation(summary= "Delete a UCSBDate")
-    // @PreAuthorize("hasRole('ROLE_ADMIN')")
-    // @DeleteMapping("")
-    // public Object deleteUCSBDate(
-    //         @Parameter(name="id") @RequestParam Long id) {
-    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+    @Operation(summary= "Delete a MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
 
-    //     ucsbDateRepository.delete(ucsbDate);
-    //     return genericMessage("UCSBDate with id %s deleted".formatted(id));
-    // }
+        menuItemReviewRepository.delete(menuItemReview);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
 
-    // @Operation(summary= "Update a single date")
-    // @PreAuthorize("hasRole('ROLE_ADMIN')")
-    // @PutMapping("")
-    // public UCSBDate updateUCSBDate(
-    //         @Parameter(name="id") @RequestParam Long id,
-    //         @RequestBody @Valid UCSBDate incoming) {
+    @Operation(summary= "Update a single review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public MenuItemReview updateMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid MenuItemReview incoming) {
 
-    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
 
-    //     ucsbDate.setQuarterYYYYQ(incoming.getQuarterYYYYQ());
-    //     ucsbDate.setName(incoming.getName());
-    //     ucsbDate.setLocalDateTime(incoming.getLocalDateTime());
+        menuItemReview.setDiningCommonsCode(incoming.getDiningCommonsCode());
+        menuItemReview.setName(incoming.getName());
+        menuItemReview.setStation(incoming.getStation());
 
-    //     ucsbDateRepository.save(ucsbDate);
+        menuItemReviewRepository.save(menuItemReview);
 
-    //     return ucsbDate;
-    // }
+        return menuItemReview;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -41,8 +41,8 @@ public class MenuItemReviewController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<MenuItemReview> allMenuItemReview() {
-        Iterable<MenuItemReview> dates = menuItemReviewRepository.findAll();
-        return dates;
+        Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
+        return reviews;
     }
 
     @Operation(summary= "Create a new review")

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,114 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/menuitemreview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+    @Autowired
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @Operation(summary= "List all menu item reviews")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<MenuItemReview> allMenuItemReview() {
+        Iterable<MenuItemReview> dates = menuItemReviewRepository.findAll();
+        return dates;
+    }
+
+    @Operation(summary= "Create a new review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public MenuItemReview postMenuItemReview(
+            @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+            @Parameter(name="name") @RequestParam String name,
+            @Parameter(name="station") @RequestParam String station
+            )
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("station={}", station);
+
+        MenuItemReview menuItemReview = new MenuItemReview();
+        menuItemReview.setDiningCommonsCode(diningCommonsCode);
+        menuItemReview.setName(name);
+        menuItemReview.setStation(station);
+
+        MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
+
+        return savedMenuItemReview;
+    }
+
+    // @Operation(summary= "Get a single date")
+    // @PreAuthorize("hasRole('ROLE_USER')")
+    // @GetMapping("")
+    // public UCSBDate getById(
+    //         @Parameter(name="id") @RequestParam Long id) {
+    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
+    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+
+    //     return ucsbDate;
+    // }
+
+    // @Operation(summary= "Delete a UCSBDate")
+    // @PreAuthorize("hasRole('ROLE_ADMIN')")
+    // @DeleteMapping("")
+    // public Object deleteUCSBDate(
+    //         @Parameter(name="id") @RequestParam Long id) {
+    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
+    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+
+    //     ucsbDateRepository.delete(ucsbDate);
+    //     return genericMessage("UCSBDate with id %s deleted".formatted(id));
+    // }
+
+    // @Operation(summary= "Update a single date")
+    // @PreAuthorize("hasRole('ROLE_ADMIN')")
+    // @PutMapping("")
+    // public UCSBDate updateUCSBDate(
+    //         @Parameter(name="id") @RequestParam Long id,
+    //         @RequestBody @Valid UCSBDate incoming) {
+
+    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
+    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+
+    //     ucsbDate.setQuarterYYYYQ(incoming.getQuarterYYYYQ());
+    //     ucsbDate.setName(incoming.getName());
+    //     ucsbDate.setLocalDateTime(incoming.getLocalDateTime());
+
+    //     ucsbDateRepository.save(ucsbDate);
+
+    //     return ucsbDate;
+    // }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -50,7 +50,7 @@ public class UCSBDatesController extends ApiController {
     public UCSBDate postUCSBDate(
             @Parameter(name="quarterYYYYQ") @RequestParam String quarterYYYYQ,
             @Parameter(name="name") @RequestParam String name,
-            @Parameter(name="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
+            @Parameter(name="localDateTime", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
             throws JsonProcessingException {
 
         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -2,6 +2,8 @@ package edu.ucsb.cs156.example.entities;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -15,6 +17,7 @@ import lombok.Builder;
 @Entity(name = "menuitemreview")
 public class MenuItemReview {
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
 
   private String diningCommonsCode;

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,23 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreview")
+public class MenuItemReview {
+  @Id
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;  
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
@@ -3,9 +3,9 @@ package edu.ucsb.cs156.example.entities;
 import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {
+}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -35,7 +35,7 @@
                   },
                   {
                     "column": {
-                      "name": "DININGCOMMONSCODE",
+                      "name": "DINING_COMMONS_CODE",
                       "type": "VARCHAR(255)"
                     }
                   },

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "MenuItemReview-1",
+          "author": "MattP",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEW"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_6"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DININGCOMMONSCODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "MENUITEMREVIEW"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -61,9 +61,9 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
 
                 // arrange
                 MenuItemReview menuItemReview1 = MenuItemReview.builder()
-                                .diningCommonsCode("din1")
-                                .name("review1")
-                                .station("station1")
+                                .diningCommonsCode("ortega")
+                                .name("Apple Pie")
+                                .station("Desserts")
                                 .build();
 
                 MenuItemReview menuItemReview2 = MenuItemReview.builder()
@@ -108,208 +108,193 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
         @Test
         public void an_admin_user_can_post_a_new_menuitemreview() throws Exception {
                 // arrange
-
-                MenuItemReview menuItemReview1 = MenuItemReview.builder()
-                                .diningCommonsCode("din1")
-                                .name("review1")
-                                .station("station1")
+                MenuItemReview menuItemReview = MenuItemReview.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Apple Pie")
+                                .station("Desserts")
                                 .build();
 
-                when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+                when(menuItemReviewRepository.save(eq(menuItemReview))).thenReturn(menuItemReview);
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/menuitemreview/post?diningCommonsCode=din1&name=review1&station=station1")
-                                                .with(csrf()))
+                                post("/api/menuitemreview/post?diningCommonsCode=ortega&name=Apple Pie&station=Desserts")
+                                                .with(csrf()))  // The URL encoded form of "Apple Pie" is "Apple%20Pie"
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
-                verify(menuItemReviewRepository, times(1)).save(menuItemReview1);
-                String expectedJson = mapper.writeValueAsString(menuItemReview1);
+                verify(menuItemReviewRepository, times(1)).save(menuItemReview);
+                String expectedJson = mapper.writeValueAsString(menuItemReview);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
 
-        // // Tests for GET /api/menuitemreview?id=...
+        // Tests for GET /api/menuitemreview?id=...
 
-        // @Test
-        // public void logged_out_users_cannot_get_by_id() throws Exception {
-        //         mockMvc.perform(get("/api/menuitemreview?id=7"))
-        //                         .andExpect(status().is(403)); // logged out users can't get by id
-        // }
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/menuitemreview?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
 
-        // @WithMockUser(roles = { "USER" })
-        // @Test
-        // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+                // arrange
+                MenuItemReview menuItemReview = MenuItemReview.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Apple Pie")
+                                .station("Desserts")
+                                .build();
 
-        //         // arrange
-        //         LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+                when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.of(menuItemReview));
 
-        //         MenuItemReview ucsbDate = MenuItemReview.builder()
-        //                         .name("firstDayOfClasses")
-        //                         .quarterYYYYQ("20222")
-        //                         .localDateTime(ldt)
-        //                         .build();
+                // act
+                MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=7"))
+                                .andExpect(status().isOk()).andReturn();
 
-        //         when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDate));
+                // assert
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=7"))
-        //                         .andExpect(status().isOk()).andReturn();
+                verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(menuItemReview);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
-        //         // assert
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+                // arrange
+                when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
-        //         verify(menuItemReviewRepository, times(1)).findById(eq(7L));
-        //         String expectedJson = mapper.writeValueAsString(ucsbDate);
-        //         String responseString = response.getResponse().getContentAsString();
-        //         assertEquals(expectedJson, responseString);
-        // }
+                // act
+                MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
 
-        // @WithMockUser(roles = { "USER" })
-        // @Test
-        // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+                // assert
 
-        //         // arrange
-
-        //         when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.empty());
-
-        //         // act
-        //         MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=7"))
-        //                         .andExpect(status().isNotFound()).andReturn();
-
-        //         // assert
-
-        //         verify(menuItemReviewRepository, times(1)).findById(eq(7L));
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("EntityNotFoundException", json.get("type"));
-        //         assertEquals("MenuItemReview with id 7 not found", json.get("message"));
-        // }
+                verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+        }
 
 
-        // // Tests for DELETE /api/menuitemreview?id=... 
+        // Tests for DELETE /api/menuitemreview?id=... 
 
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_can_delete_a_date() throws Exception {
-        //         // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_review() throws Exception {
+                // arrange
+                MenuItemReview menuItemReview = MenuItemReview.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Apple Pie")
+                                .station("Desserts")
+                                .build();
 
-        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(menuItemReview));
 
-        //         MenuItemReview ucsbDate1 = MenuItemReview.builder()
-        //                         .name("firstDayOfClasses")
-        //                         .quarterYYYYQ("20222")
-        //                         .localDateTime(ldt1)
-        //                         .build();
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/menuitemreview?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
-        //         when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(ucsbDate1));
+                // assert
+                verify(menuItemReviewRepository, times(1)).findById(15L);
+                verify(menuItemReviewRepository, times(1)).delete(any());
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         delete("/api/menuitemreview?id=15")
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isOk()).andReturn();
-
-        //         // assert
-        //         verify(menuItemReviewRepository, times(1)).findById(15L);
-        //         verify(menuItemReviewRepository, times(1)).delete(any());
-
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
-        // }
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+        }
         
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
-        //                 throws Exception {
-        //         // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_menuitemreview_and_gets_right_error_message()
+                        throws Exception {
 
-        //         when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+                // arrange
+                when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         delete("/api/menuitemreview?id=15")
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isNotFound()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/menuitemreview?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
 
-        //         // assert
-        //         verify(menuItemReviewRepository, times(1)).findById(15L);
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("MenuItemReview with id 15 not found", json.get("message"));
-        // }
+                // assert
+                verify(menuItemReviewRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 15 not found", json.get("message"));
+        }
 
-        // // Tests for PUT /api/menuitemreview?id=... 
+        // Tests for PUT /api/menuitemreview?id=... 
 
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_can_edit_an_existing_ucsbdate() throws Exception {
-        //         // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+            
+                // arrange
+                MenuItemReview menuItemReviewOrig = MenuItemReview.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Apple Pie")
+                                .station("Desserts")
+                                .build();
 
-        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-        //         LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+                MenuItemReview menuItemReviewEdited = MenuItemReview.builder()
+                                .diningCommonsCode("portola")
+                                .name("Turkey Sandwich")
+                                .station("Sandwiches")
+                                .build();
 
-        //         MenuItemReview ucsbDateOrig = MenuItemReview.builder()
-        //                         .name("firstDayOfClasses")
-        //                         .quarterYYYYQ("20222")
-        //                         .localDateTime(ldt1)
-        //                         .build();
+                String requestBody = mapper.writeValueAsString(menuItemReviewEdited);
 
-        //         MenuItemReview ucsbDateEdited = MenuItemReview.builder()
-        //                         .name("firstDayOfFestivus")
-        //                         .quarterYYYYQ("20232")
-        //                         .localDateTime(ldt2)
-        //                         .build();
+                when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(menuItemReviewOrig));
 
-        //         String requestBody = mapper.writeValueAsString(ucsbDateEdited);
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/menuitemreview?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
-        //         when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
-
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         put("/api/menuitemreview?id=67")
-        //                                         .contentType(MediaType.APPLICATION_JSON)
-        //                                         .characterEncoding("utf-8")
-        //                                         .content(requestBody)
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isOk()).andReturn();
-
-        //         // assert
-        //         verify(menuItemReviewRepository, times(1)).findById(67L);
-        //         verify(menuItemReviewRepository, times(1)).save(ucsbDateEdited); // should be saved with correct user
-        //         String responseString = response.getResponse().getContentAsString();
-        //         assertEquals(requestBody, responseString);
-        // }
+                // assert
+                verify(menuItemReviewRepository, times(1)).findById(67L);
+                verify(menuItemReviewRepository, times(1)).save(menuItemReviewEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
 
         
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
-        //         // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+                // arrange
+                MenuItemReview menuEditedReview = MenuItemReview.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Apple Pie")
+                                .station("Desserts")
+                                .build();
 
-        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                String requestBody = mapper.writeValueAsString(menuEditedReview);
 
-        //         MenuItemReview ucsbEditedDate = MenuItemReview.builder()
-        //                         .name("firstDayOfClasses")
-        //                         .quarterYYYYQ("20222")
-        //                         .localDateTime(ldt1)
-        //                         .build();
+                when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
 
-        //         String requestBody = mapper.writeValueAsString(ucsbEditedDate);
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/menuitemreview?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
 
-        //         when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+                // assert
+                verify(menuItemReviewRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 67 not found", json.get("message"));
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         put("/api/menuitemreview?id=67")
-        //                                         .contentType(MediaType.APPLICATION_JSON)
-        //                                         .characterEncoding("utf-8")
-        //                                         .content(requestBody)
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isNotFound()).andReturn();
-
-        //         // assert
-        //         verify(menuItemReviewRepository, times(1)).findById(67L);
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("MenuItemReview with id 67 not found", json.get("message"));
-
-        // }
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,315 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+
+        @MockBean
+        MenuItemReviewRepository menuItemReviewRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/menuitemreview/all
+        
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/menuitemreview/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/menuitemreview/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_menuitemreview() throws Exception {
+
+                // arrange
+                MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                                .diningCommonsCode("din1")
+                                .name("review1")
+                                .station("station1")
+                                .build();
+
+                MenuItemReview menuItemReview2 = MenuItemReview.builder()
+                                .diningCommonsCode("din2")
+                                .name("review2")
+                                .station("station2")
+                                .build();
+
+                ArrayList<MenuItemReview> expectedReviews = new ArrayList<>();
+                expectedReviews.addAll(Arrays.asList(menuItemReview1, menuItemReview2));
+
+                when(menuItemReviewRepository.findAll()).thenReturn(expectedReviews);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/menuitemreview/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(menuItemReviewRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedReviews);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for POST /api/menuitemreview/post...
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/menuitemreview/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/menuitemreview/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_menuitemreview() throws Exception {
+                // arrange
+
+                MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                                .diningCommonsCode("din1")
+                                .name("review1")
+                                .station("station1")
+                                .build();
+
+                when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/menuitemreview/post?diningCommonsCode=din1&name=review1&station=station1")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(menuItemReviewRepository, times(1)).save(menuItemReview1);
+                String expectedJson = mapper.writeValueAsString(menuItemReview1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // // Tests for GET /api/menuitemreview?id=...
+
+        // @Test
+        // public void logged_out_users_cannot_get_by_id() throws Exception {
+        //         mockMvc.perform(get("/api/menuitemreview?id=7"))
+        //                         .andExpect(status().is(403)); // logged out users can't get by id
+        // }
+
+        // @WithMockUser(roles = { "USER" })
+        // @Test
+        // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+        //         // arrange
+        //         LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+        //         MenuItemReview ucsbDate = MenuItemReview.builder()
+        //                         .name("firstDayOfClasses")
+        //                         .quarterYYYYQ("20222")
+        //                         .localDateTime(ldt)
+        //                         .build();
+
+        //         when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDate));
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=7"))
+        //                         .andExpect(status().isOk()).andReturn();
+
+        //         // assert
+
+        //         verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+        //         String expectedJson = mapper.writeValueAsString(ucsbDate);
+        //         String responseString = response.getResponse().getContentAsString();
+        //         assertEquals(expectedJson, responseString);
+        // }
+
+        // @WithMockUser(roles = { "USER" })
+        // @Test
+        // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+        //         // arrange
+
+        //         when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=7"))
+        //                         .andExpect(status().isNotFound()).andReturn();
+
+        //         // assert
+
+        //         verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("EntityNotFoundException", json.get("type"));
+        //         assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+        // }
+
+
+        // // Tests for DELETE /api/menuitemreview?id=... 
+
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void admin_can_delete_a_date() throws Exception {
+        //         // arrange
+
+        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+        //         MenuItemReview ucsbDate1 = MenuItemReview.builder()
+        //                         .name("firstDayOfClasses")
+        //                         .quarterYYYYQ("20222")
+        //                         .localDateTime(ldt1)
+        //                         .build();
+
+        //         when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(ucsbDate1));
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         delete("/api/menuitemreview?id=15")
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isOk()).andReturn();
+
+        //         // assert
+        //         verify(menuItemReviewRepository, times(1)).findById(15L);
+        //         verify(menuItemReviewRepository, times(1)).delete(any());
+
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+        // }
+        
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+        //                 throws Exception {
+        //         // arrange
+
+        //         when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         delete("/api/menuitemreview?id=15")
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isNotFound()).andReturn();
+
+        //         // assert
+        //         verify(menuItemReviewRepository, times(1)).findById(15L);
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("MenuItemReview with id 15 not found", json.get("message"));
+        // }
+
+        // // Tests for PUT /api/menuitemreview?id=... 
+
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+        //         // arrange
+
+        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+        //         LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+        //         MenuItemReview ucsbDateOrig = MenuItemReview.builder()
+        //                         .name("firstDayOfClasses")
+        //                         .quarterYYYYQ("20222")
+        //                         .localDateTime(ldt1)
+        //                         .build();
+
+        //         MenuItemReview ucsbDateEdited = MenuItemReview.builder()
+        //                         .name("firstDayOfFestivus")
+        //                         .quarterYYYYQ("20232")
+        //                         .localDateTime(ldt2)
+        //                         .build();
+
+        //         String requestBody = mapper.writeValueAsString(ucsbDateEdited);
+
+        //         when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         put("/api/menuitemreview?id=67")
+        //                                         .contentType(MediaType.APPLICATION_JSON)
+        //                                         .characterEncoding("utf-8")
+        //                                         .content(requestBody)
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isOk()).andReturn();
+
+        //         // assert
+        //         verify(menuItemReviewRepository, times(1)).findById(67L);
+        //         verify(menuItemReviewRepository, times(1)).save(ucsbDateEdited); // should be saved with correct user
+        //         String responseString = response.getResponse().getContentAsString();
+        //         assertEquals(requestBody, responseString);
+        // }
+
+        
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+        //         // arrange
+
+        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+        //         MenuItemReview ucsbEditedDate = MenuItemReview.builder()
+        //                         .name("firstDayOfClasses")
+        //                         .quarterYYYYQ("20222")
+        //                         .localDateTime(ldt1)
+        //                         .build();
+
+        //         String requestBody = mapper.writeValueAsString(ucsbEditedDate);
+
+        //         when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         put("/api/menuitemreview?id=67")
+        //                                         .contentType(MediaType.APPLICATION_JSON)
+        //                                         .characterEncoding("utf-8")
+        //                                         .content(requestBody)
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isNotFound()).andReturn();
+
+        //         // assert
+        //         verify(menuItemReviewRepository, times(1)).findById(67L);
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("MenuItemReview with id 67 not found", json.get("message"));
+
+        // }
+}


### PR DESCRIPTION
This PR enhances the `MenuItemReviewController` by introducing endpoints for `MenuItemReview` entities. It includes:

- A `GET` (index) endpoint for listing all menu item reviews, allowing for getting all reviews in the `MenuItemReview` table.
- A `POST` (create) endpoint for creating new menu item reviews, facilitating the addition of new reviews to the database.
- An additional `GET` (show) endpoint for retrieving a single record, allowing for retrieving a specific menu item review.
- A `PUT` (edit) endpoint for updating existing records in the `MenuItemReview` table, allowing for modifications to existing reviews.
- A `DELETE` endpoint for removing specific records, providing functionality to delete a review with the specified id.

Closes #27 #28 #29 #30

Dev deployment: https://team02-luxiangzh-dev.dokku-12.cs.ucsb.edu/